### PR TITLE
Bugfix: Support training callbacks on steps when validations are not performed

### DIFF
--- a/src/ltxv_trainer/trainer.py
+++ b/src/ltxv_trainer/trainer.py
@@ -5,7 +5,7 @@ import warnings
 from copy import deepcopy
 from functools import partial
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Optional, List
 from unittest.mock import MagicMock
 
 import torch
@@ -204,6 +204,7 @@ class LtxvTrainer:
                         self._lr_scheduler.step()
 
                     # Run validation if needed
+                    sampled_videos_paths: List[Path] = []
                     if (
                         cfg.validation.interval
                         and self._global_step > 0


### PR DESCRIPTION
Currently, when passing a `step_callback` to `trainer.train`, you will receive a scoping exception on any step a validation is not performed but a callback is attempted.