### PR TITLE
docs: correct convert_checkpoint.py --ouput-path argument

### DIFF
--- a/docs/utility-scripts.md
+++ b/docs/utility-scripts.md
@@ -10,10 +10,10 @@ The `scripts/convert_checkpoint.py` script converts LoRA weights between Diffuse
 
 ```bash
 # Convert from Diffusers to ComfyUI format
-python scripts/convert_checkpoint.py input.safetensors --to-comfy --output_path output.safetensors
+python scripts/convert_checkpoint.py input.safetensors --to-comfy --output-path output.safetensors
 
 # Convert from ComfyUI to Diffusers format
-python scripts/convert_checkpoint.py input.safetensors --output_path output.safetensors
+python scripts/convert_checkpoint.py input.safetensors --output-path output.safetensors
 ```
 
 **Key features:**


### PR DESCRIPTION
I've been instinctively writing it correctly all this time, then I realized today in the docs it's an underscore `_` instead of a dash `-`, which yields this error of course : 
```
 No such option: --output_path Did you mean --output-path? 
```